### PR TITLE
Review Makefile for critical issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -454,7 +454,7 @@ docker-run: dep/docker $(DOCKER_BUILD_STAMP)  ## Run the Docker container
 	@echo -e "$(GREEN)Docker container executed.$(RESET)"
 
 .PHONY: docker-all
-docker-all: build run  ## Build and run the Docker container
+docker-all: docker-build docker-run  ## Build and run the Docker container
 
 .PHONY: docker-stop
 docker-stop: | dep/docker dep/docker-compose  ## Stop the Docker container


### PR DESCRIPTION
This pull request makes minor improvements to the `Makefile` related to dependency management and Docker commands. The changes mostly address small corrections and clarify command usage.

- **Dependency Management:**
  * Corrected a typo in the `dep/uv` target to display "uv not found" instead of "un not found" when the `UV` variable is missing.

- **Production Installation:**
  * Fixed a formatting issue in the production installation message by adding a newline before the message output.

- **Docker Commands:**
  * Updated the `docker-all` target to use the more explicit `docker-build` and `docker-run` targets instead of the generic `build` and `run`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed error message typos and formatting inconsistencies in build tooling.
  * Improved readability of build tool output messages.
  * Updated build command dependencies for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->