### PR TITLE
Add contents write permission to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required to push to gh-pages branch
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Fix GitHub Actions permission error by adding explicit contents: write permission to the docs job. This allows the built-in github.token to push to the gh-pages branch without requiring a custom PAT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions configuration to support reliable documentation deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->