### PR TITLE
Verify Check commands in Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy app files
-COPY pyrays pyrays
+COPY pyrays/src pyrays
 COPY entrypoint.sh entrypoint.sh
 RUN chmod +x entrypoint.sh
 


### PR DESCRIPTION
Update COPY command to correctly copy pyrays/src to pyrays directory. This ensures the package structure matches what entrypoint.sh expects when running 'python -m pyrays'.

Previously, COPY pyrays pyrays resulted in /app/pyrays/src/__init__.py which would fail when trying to run the module.