### PR TITLE
Fix config file path to work in Docker container

### DIFF
--- a/pyrays/src/config/__init__.py
+++ b/pyrays/src/config/__init__.py
@@ -1,5 +1,11 @@
 """The config is a package that does XYZ."""
 
+import os
+
 from .config import Config
 
-config = Config("pyrays/src/config/config.json")
+# Use path relative to this file's location for portability
+_config_dir = os.path.dirname(os.path.abspath(__file__))
+_config_path = os.path.join(_config_dir, "config.json")
+
+config = Config(_config_path)


### PR DESCRIPTION
Replace hardcoded path 'pyrays/src/config/config.json' with a relative path based on the current file's location. This ensures the config file can be found both when running locally and inside the Docker container.

The previous hardcoded path worked locally but failed in Docker because the container structure differs after COPY pyrays/src -> /app/pyrays.