### PR TITLE
Fix release action trigger for version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '[0-9]+.*'
+      - 'v[0-9]+.*'
 
 env:
   PACKAGE_NAME: ''


### PR DESCRIPTION
This pull request makes a minor update to the release workflow configuration to support an additional tag format for triggering releases.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R7): The workflow now triggers on tags matching both the previous numeric pattern and the new `v`-prefixed pattern (e.g., `v1.2.3`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to support additional tag naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->