### PR TITLE
Improve virtualenv Python version detection using uv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,13 +184,13 @@ python: | dep/uv  ## Check if Python is installed
 virtualenv: | dep/uv  ## Check if virtualenv exists - create it if not
 	@echo -e "$(CYAN)\nChecking Python and virtualenv setup...$(RESET)"
 	@PYTHON_MAJOR_MINOR=$$(echo $(PYTHON_VERSION) | $(AWK) -F. '{print $$1"."$$2}'); \
-	if ! $(PYTHON) --version 2>/dev/null | grep -q "$$PYTHON_MAJOR_MINOR" ; then \
+	if $(UV) python list | grep -q "cpython-$$PYTHON_MAJOR_MINOR" ; then \
+		FOUND_VERSION=$$($(UV) python list | grep "cpython-$$PYTHON_MAJOR_MINOR" | head -1 | $(AWK) '{print $$1}' | $(SED) 's/cpython-//'); \
+		echo -e "$(GREEN)Python version $$FOUND_VERSION is available.$(RESET)"; \
+	else \
 		echo -e "$(YELLOW)Python version $$PYTHON_MAJOR_MINOR not found, installing $(PYTHON_VERSION)...$(RESET)"; \
 		$(UV) python install $(PYTHON_VERSION) || exit 1; \
 		echo -e "$(GREEN)Python version $(PYTHON_VERSION) installed.$(RESET)"; \
-	else \
-		INSTALLED_VERSION=$$($(PYTHON) --version 2>&1 | $(AWK) '{print $$2}'); \
-		echo -e "$(GREEN)Python version $$INSTALLED_VERSION is available.$(RESET)"; \
 	fi
 	@if ! ls $(VIRTUALENV_NAME) > /dev/null 2>&1 ; then \
 		echo -e "$(YELLOW)Local virtualenv not found. Creating it...$(RESET)"; \


### PR DESCRIPTION
Changes:
- Check for Python availability via 'uv python list' instead of system Python
- This ensures we detect Python versions managed by uv correctly
- Shows the actual available Python version (e.g., 3.11.14-linux-x86_64-gnu)
- Eliminates false "Python not found" messages when Python is available via uv

Fixes the issue where virtualenv would attempt to install Python even when an appropriate version was already available through uv.